### PR TITLE
Moves site config settings to slot

### DIFF
--- a/apps/umbraco-base-v2/azuredeploy.json
+++ b/apps/umbraco-base-v2/azuredeploy.json
@@ -363,25 +363,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "serverFarmId": "[resourceId(parameters('appServiceResourceGroup'), 'Microsoft.Web/serverfarms', parameters('appserviceName'))]",
-                "httpsOnly": true,
-                "siteConfig": {
-                    "clientAffinityEnabled": true,
-                    "phpVersion": "",
-                    "webSocketsEnabled": false,
-                    "requestTracingEnabled": true,
-                    "httpLoggingEnabled": true,
-                    "logsDirectorySizeLimit": 40,
-                    "detailedErrorLoggingEnabled": true,
-                    "ftpsState": "Disabled",
-                    "minTlsVersion": "1.2",
-                    "http20Enabled": true,
-                    "alwaysOn": true,
-                    "use32BitWorkerProcess": false,
-                    "remoteDebuggingEnabled": false,
-                    "siteAuthEnabled": false,
-                    "netFrameworkVersion": "v4.6"
-                }
+                "serverFarmId": "[resourceId(parameters('appServiceResourceGroup'), 'Microsoft.Web/serverfarms', parameters('appserviceName'))]"
             },
             "resources": [
                 {
@@ -402,7 +384,26 @@
                     "dependsOn": [
                         "[concat('Microsoft.Web/Sites/', variables('siteName'))]"
                     ],
-                    "properties": {},
+                    "properties": {
+                        "httpsOnly": true,
+                        "siteConfig": {
+                            "clientAffinityEnabled": true,
+                            "phpVersion": "",
+                            "webSocketsEnabled": false,
+                            "requestTracingEnabled": true,
+                            "httpLoggingEnabled": true,
+                            "logsDirectorySizeLimit": 40,
+                            "detailedErrorLoggingEnabled": true,
+                            "ftpsState": "Disabled",
+                            "minTlsVersion": "1.2",
+                            "http20Enabled": true,
+                            "alwaysOn": true,
+                            "use32BitWorkerProcess": false,
+                            "remoteDebuggingEnabled": false,
+                            "siteAuthEnabled": false,
+                            "netFrameworkVersion": "v4.6"
+                        }
+                    },
                     "resources": [
                         {
                             "apiVersion": "2018-02-01",


### PR DESCRIPTION
This stops the site config being updates on the production slot during deployment, before the swap