### PR TITLE
Add disable overlapped recycling setting to umbraco web app

### DIFF
--- a/apps/umbraco-base-v3/azuredeploy.json
+++ b/apps/umbraco-base-v3/azuredeploy.json
@@ -383,6 +383,7 @@
                                 "[resourceId('Microsoft.Web/sites/slots', variables('siteName'), variables('siteDeploySlotName'))]"
                             ],
                             "properties": {
+                                "WEBSITE_DISABLE_OVERLAPPED_RECYCLING": 1,
                                 "WEBSITE_TIME_ZONE": "[parameters('appTimeZone')]",
                                 "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(variables('appInsightsResource')).InstrumentationKey]",
                                 "APPINSIGHTS_DEVELOPER_MODE": "[if(equals(variables('isProdDeploy'), 'true'), 'false', 'true')]",


### PR DESCRIPTION
Regarding this issue in UmbracoCMS where the NuCache.Content.db file will become locked when swapping slots in Azure. 
https://github.com/umbraco/Umbraco-CMS/issues/6546


The given fix is to add a `WEBSITE_DISABLE_OVERLAPPED_RECYCLING` app setting:
https://github.com/umbraco/Umbraco-CMS/issues/6546#issuecomment-545224926 

This was added to the Umbraco docs for Azure hosting here:
https://github.com/umbraco/UmbracoDocs/pull/2042